### PR TITLE
Add Headscale and Cloudflare integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,6 @@
-This is the repository of the Tailscale-Caddy proxy, a docker image that enables easy sharing of docker HTTP services over the Tailscale network via HTTPS.
+This is the repository of the Headscale/Caddy/Cloudflare proxy, a docker image that enables easy sharing of docker HTTP services over your own Headscale network via HTTPS.
 
-# Rationale
-
-I have a few docker web services I want to share with other users.
-
-Before Tailscale this would mean opening firewall ports and enabling authentication for the users. And then you still need to worry about the fact that your services are exposed to the world. 
-
-Tailscale enables you to share devices securely. Setup is trivial and the maintenance of who can access what is very convenient.
-
-So, I want to share web services via Tailscale. I found that there are multiple existing solutions such as:
-* the [Tailscale Docker Desktop extension](https://tailscale.com/blog/docker/), 
-* the [Tailscale sidecar](https://github.com/markpash/tailscale-sidecar) by markpash 
-* the official [Tailscale docker image](https://hub.docker.com/r/tailscale/tailscale).
-
-None of those solutions fit my usage scenario so I built the solution that is available in this repo.
-
-Compared to the other solutions this image:
-
-* does an auto-refresh of the SSL certificates without any further required actions by the user
-* supports a restart of the service container without having to restart the Tailscale/Caddy container
-
-# Functional description
-
-I want to be able to serve a web application to users by running a container in parallel to the container that serves the application. The side container should perform:
-
-* the connection to the Tailscale network
-* take care of serving the application via HTTPS with valid and regularly updated SSL certificates
-
-To implement this I start from the official Tailscale docker image and I extend it with Caddy. A small script that runs when starting the container takes care of creating the right configuration file for Caddy based on the environment parameters that are set when launching the container. 
-
-Once started the container brings up the Tailscale connection. Users with access to the Tailscale device can connect over HTTP to port 80 (which is redirected to HTTPS) or to port 443 over HTTPS directly. The Caddy reverse proxy takes care of negotiating SSL certificated with the Tailscale daemon in the container to present valid HTTPS certificates.
-
-![block-diagram](https://github.com/hollie/tailscale-caddy-proxy/raw/main/visuals/block-diagram.png)
-
-# Requirements
-
-For this image to work correctly you need to enable HTTPS support and MagicDNS in your Tailscale network configuration.
+Please visit [the original repository](https://github.com/hollie/tailscale-caddy-proxy) for the original rationale and additional explanations. This fork adds support for Cloudflare-based DNS challenges so MagicDNS-hosts will automatically request and use SSL certificates from Let's Encrypt.
 
 # Parameters and storage
 
@@ -43,56 +8,66 @@ The docker image takes as input parameters:
 
 * `TS_HOSTNAME` : the name of the host on the Tailscale network
 
-* `TS_TAILNET`: the name of your tailnet **without** the trailing `ts.net` section.
+* `TS_TAILNET`: the **full** name of your tailnet. The original container omitted the `.ts.net` suffix, but since Headscale works differently you need to specify your full MagicDNS base domain.
 
 * `CADDY_TARGET`: the name and port of the service you want to connect to.
+
+* `TS_EXTRA_ARGS`: Additional arguments supplied to `tailscale up`. This ususally needs to contain your Headscale URL in the form of `--login-server https://your-headscale.domain.com`
+
+* `CLOUDFLARE_DNS_API_TOKEN`: A Cloudflare API token that is able to modify DNS entries for your configured MagicDNS domain.
 
 You also want to declare a permanent volume to store the Tailscale credentials so that those survive a rebuild of the container. The Tailscale configuration is located in the folder `/var/lib/tailscale` in the container.
 
 # Practical use
 
-Say you have an example service called 'whoami' that is a simple webserver listening on port 80 and you want to expose it via Tailscale.
+Say you have an example service called 'whoami' that is a simple webserver listening on port 80 and you want to expose it via Headscale.
 
-We want to keep the network traffic between this container and the Tailscale proxy separated from the default docker network, so declare a network. Attach the whoami container to that network. Declare a container of the `hollie/tailscale-caddy-proxy` image next to it, attach it also to the same network and enter the right environmental parameters for the Tailscale and Caddy configuration.
+We want to keep the network traffic between this container and the Headscale proxy separated from the default docker network, so declare a network. Attach the whoami container to that network. Declare a container of the `dkoch/headscale-caddy-cloudflare-proxy` image next to it, attach it also to the same network and enter the right environmental parameters for the Headscale and Caddy configuration.
 
 The resulting docker compose file looks like:
 
 ```docker
-version: '3'
-
 networks:
-  tailscale_proxy_example:
+  headscale_proxy_example:
     external: false
 
 volumes:
-  tailscale-whoami-state:
+  headscale-whoami-state:
 
 services:
-
   whoami:
     image: traefik/whoami
     networks:
-     - tailscale_proxy_example
+     - headscale_proxy_example
 
-  tailscale-whoami-proxy:
-    image: hollie/tailscale-caddy-proxy:latest
+  headscale-whoami-proxy:
+    image: foo
     volumes:
-      - tailscale-whoami-state:/var/lib/tailscale # Persist tailscale state
+      # Persist the tailscale state directory so login state etc. is retained between restarts.
+      - headscale-whoami-state:/var/lib/tailscale
     environment:
-      - TS_HOSTNAME=tailscale-example # Hostname on the tailscale network
-      - TS_TAILNET=tailnet-XXXX       # Your tailnet name without the .ts.net suffix!
-      - CADDY_TARGET=whoami:80        # Target service and port
-#      - TS_EXTRA_ARGS=<optional extra arguments> # When starting tailscale in the container, e.g. to allow exit node or override the DNS settings. 
+      # Hostname you want this instance to have on your headscale network
+      - TS_HOSTNAME=headscale-example
+      # Your tailnet name including the full top level domain(s).
+      - TS_TAILNET=vpn.dkoch.org
+      # Target service and port
+      - CADDY_TARGET=whoami:80
+      # Optional extra arguments to pass when starting tailscale. Use this to include your Headscale login URL.
+      - TS_EXTRA_ARGS=--login-server https://your-headscale.domain.com
+      # Cloudflare API token that is able to modify DNS entries for your configured MagicDNS domain.
+      - CLOUDFLARE_DNS_API_TOKEN=your_cloudflare_token_here
     restart: on-failure
     init: true
     networks:
-     - tailscale_proxy_example
+     - headscale_proxy_example
 ```
 
-Run `docker-compose up` and visit the link that is printed in the terminal to authenticate the machine to your Tailscale network. Disable key expiry via the Tailscale settings page for this host and restart the containers with `docker compose up -d`. 
+Run `docker-compose up` and visit the link that is printed in the terminal to authenticate the machine to your Tailscale network. Disable key expiry via the Tailscale settings page for this host and restart the containers with `docker compose up -d`.
 
 All set! Now you can access the host via the full Tailscale domainname (including the tailnet-XXX.ts.net).
 
 # Acknowledgements
+
+Thank you so much to hollie / Lieven Hollevoet for the [original implementation](https://github.com/hollie/tailscale-caddy-proxy)!
 
 Thanks to lpasselin for his [example code](https://github.com/lpasselin/tailscale-docker) that shows how to extend the default Tailscale image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,33 @@
 networks:
-  tailscale_proxy_example:
+  headscale_proxy_example:
     external: false
 
 volumes:
-  tailscale-whoami-state:
+  headscale-whoami-state:
 
 services:
-
   whoami:
     image: traefik/whoami
     networks:
-     - tailscale_proxy_example
+     - headscale_proxy_example
 
-  tailscale-whoami-proxy:
-    image: hollie/tailscale-caddy-proxy:latest
+  headscale-whoami-proxy:
+    image: dieterkoch/headscale-caddy-cloudflare-proxy
     volumes:
-      - tailscale-whoami-state:/var/lib/tailscale # Persist the tailscale state directory
+      # Persist the tailscale state directory so login state etc. is retained between restarts.
+      - headscale-whoami-state:/var/lib/tailscale
     environment:
-      - TS_HOSTNAME=tailscale-example 	# Hostname you want this instance to have on the tailscale network
-      - TS_TAILNET=tailnet-XXXX         # Your tailnet name without the .ts.net suffix!
-      - CADDY_TARGET=whoami:80		# Target service and port
-#      - TS_EXTRA_ARGS=--accept-dns      # Optional extra arguments to pass when starting tailscale
-#      - SKIP_CADDYFILE_GENERATION=1     # Set this if you want to be able to override /etc/caddy/Caddyfile via a volume mapping      
+      # Hostname you want this instance to have on your headscale network.
+      - TS_HOSTNAME=headscale-example
+      # Your tailnet name including the full top level domain(s).
+      - TS_TAILNET=vpn.example.com
+      # Target service and port.
+      - CADDY_TARGET=whoami:80
+      # Optional extra arguments to pass when starting tailscale. Use this to include your Headscale login URL.
+      - TS_EXTRA_ARGS=--login-server https://headscale.example.com
+      # Cloudflare API token that is able to modify DNS entries for your configured MagicDNS domain.
+      - CLOUDFLARE_DNS_API_TOKEN=your_cloudflare_token_here
     restart: on-failure
     init: true
     networks:
-     - tailscale_proxy_example
+     - headscale_proxy_example

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,19 +1,29 @@
 ARG TAILSCALE_VERSION=v1.82.5
 
+# Build Caddy with Cloudflare DNS integration.
+FROM caddy:builder-alpine AS builder
+RUN caddy-builder github.com/caddy-dns/cloudflare
+
+# Build the actual deployment image using Tailscale.
 FROM tailscale/tailscale:$TAILSCALE_VERSION
 
-LABEL maintainer="hollie@lika.be"
+LABEL maintainer="dk@dkoch.org"
 
 ENV CADDY_TARGET=
+ENV CLOUDFLARE_DNS_API_TOKEN=
 ENV TS_TAILNET=
 ENV TS_HOSTNAME=
-ENV TS_EXTRA_FLAGS=
+ENV TS_EXTRA_ARGS=
 ENV TS_USERSPACE=true
-ENV TS_STATE_DIR=/var/lib/tailscale/ 
+ENV TS_STATE_DIR=/var/lib/tailscale/
 ENV TS_AUTH_ONCE=true
 
-RUN apk update && apk upgrade --no-cache && apk add --no-cache ca-certificates mailcap caddy
-RUN caddy upgrade
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates mailcap && \
+    caddy upgrade
 
 # Ensure Caddy can access the tailscale socket, Caddy expects it to be under /var/run/tailscale so make a symlink
 RUN mkdir --parents /var/run/tailscale && ln -s /tmp/tailscaled.sock /var/run/tailscale/tailscaled.sock
@@ -24,5 +34,3 @@ RUN  chmod +x /usr/bin/start.sh
 
 # And run it
 CMD  [ "start.sh" ]
-
-

--- a/image/release-to-dockerhub.sh
+++ b/image/release-to-dockerhub.sh
@@ -1,13 +1,12 @@
 set -ex
 # SET THE FOLLOWING VARIABLES
 # docker hub username
-USERNAME=hollie
+USERNAME=dieterkoch
 # image name
-IMAGE=tailscale-caddy-proxy
+IMAGE=headscale-caddy-cloudflare-proxy
 # platforms
 PLATFORM=linux/arm64,linux/amd64,linux/arm/v7
 # bump version
-#docker run --rm -v "$PWD":/app treeder/bump patch
 version=`awk -F "=" '/TAILSCALE_VERSION=/{print $NF}' Dockerfile`
 echo "Building version: $version"
 # run build

--- a/image/start.sh
+++ b/image/start.sh
@@ -9,8 +9,22 @@ if [ ! -z "$SKIP_CADDYFILE_GENERATION" ] ; then
 else
    echo "Building Caddy configfile"
 
-   echo $TS_HOSTNAME'.'$TS_TAILNET.'ts.net' > /etc/caddy/Caddyfile
+   mkdir -p /etc/caddy
+
+   echo $TS_HOSTNAME'.'$TS_TAILNET > /etc/caddy/Caddyfile
    echo 'reverse_proxy' $CADDY_TARGET >> /etc/caddy/Caddyfile
+
+   if [ ! -z "$CLOUDFLARE_DNS_API_TOKEN" ] ; then
+      echo "Note: Using Cloudflare-based DNS challenge for Let's Encrypt."
+
+cat >> /etc/caddy/Caddyfile <<EOL
+tls {
+  dns cloudflare ${CLOUDFLARE_DNS_API_TOKEN}
+}
+EOL
+
+      caddy fmt /etc/caddy/Caddyfile --overwrite
+   fi
 fi
 
 echo "Starting Caddy"


### PR DESCRIPTION
This PR adds support for custom MagicDNS-domains as used by Headscale and automatic SSL certificates for them through DNS-based challenges using Cloudflare.